### PR TITLE
Fix title scraper in TwitterScraper

### DIFF
--- a/src/scraper/TwitterScraper.php
+++ b/src/scraper/TwitterScraper.php
@@ -7,7 +7,7 @@ class TwitterScraper extends XpathScraper
     public function __construct()
     {
         $this->xpathItem = "//*[contains(@class, 'original-tweet')]";
-        $this->xpathTitle = ".//p[contains(@class, 'TweetTextSize')]/text()";
+        $this->xpathTitle = ".//p[contains(@class, 'TweetTextSize')]";
         $this->xpathLink = ".//a[contains(@class, 'tweet-timestamp')]/@href";
         $this->xpathAuthor = ".//strong[contains(@class, 'fullname')]/text()";
         $this->xpathDate = ".//span[contains(@class, '_timestamp')]/@data-time";


### PR DESCRIPTION
At the moment only the first text-node is extracted. But often a tweet contains several nodes (text-nodes, link-nodes) and we should consider all of them (this is also important for the no facebook tweets). See also the example https://twitter.com/infolis_project
